### PR TITLE
Fix backlog accessor usage bug

### DIFF
--- a/src/UnTaskAlert/MonitoringService.cs
+++ b/src/UnTaskAlert/MonitoringService.cs
@@ -28,7 +28,7 @@ public class MonitoringService(INotifier notifier, IBacklogAccessor backlogAcces
         var activeTaskInfo = await _backlogAccessor.GetActiveWorkItems(connection, subscriber.Email, log);
         foreach (var taskInfo in activeTaskInfo.TasksInfo)
         {
-            taskInfo.ActiveTime = (await backlogAccessor.GetWorkItemActiveTime(connection, taskInfo.Id)).TotalHours;
+            taskInfo.ActiveTime = (await _backlogAccessor.GetWorkItemActiveTime(connection, taskInfo.Id)).TotalHours;
         }
 
         await CreateAlertIfNeeded(subscriber, activeTaskInfo, log, cancellationToken);

--- a/src/UnTaskAlert/ReportingService.cs
+++ b/src/UnTaskAlert/ReportingService.cs
@@ -38,8 +38,8 @@ public class ReportingService(INotifier notifier, IBacklogAccessor backlogAccess
         var activeTaskInfo = await _backlogAccessor.GetActiveWorkItems(connection, subscriber.Email, log);
         foreach (var taskInfo in activeTaskInfo.TasksInfo)
         {
-            taskInfo.ActiveTime = (await backlogAccessor.GetWorkItemActiveTime(connection, taskInfo.Id)).TotalHours;
-            var parent = await backlogAccessor.GetParentUserStory(connection, taskInfo.Id);
+            taskInfo.ActiveTime = (await _backlogAccessor.GetWorkItemActiveTime(connection, taskInfo.Id)).TotalHours;
+            var parent = await _backlogAccessor.GetParentUserStory(connection, taskInfo.Id);
             taskInfo.Parent = new TaskInfo(parent);
         }
 
@@ -154,7 +154,7 @@ public class ReportingService(INotifier notifier, IBacklogAccessor backlogAccess
         {
             if (workItem.Id == null) continue;
             var workItemId = workItem.Id.Value;
-            var activeTime = await backlogAccessor.GetWorkItemActiveTime(connection, workItemId);
+            var activeTime = await _backlogAccessor.GetWorkItemActiveTime(connection, workItemId);
 
             if (!workItem.Fields.TryGetValue<double>("Microsoft.VSTS.Scheduling.OriginalEstimate", out var estimated))
             {


### PR DESCRIPTION
## Summary
- fix private field `_backlogAccessor` references in `ReportingService`
- fix private field `_backlogAccessor` reference in `MonitoringService`

## Testing
- `dotnet build src/UnTaskAlert/UnTaskAlert.csproj -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68407965196883238c2fe7de913a95ec